### PR TITLE
Revert "Add results_redis_publish=true for haraka-results changes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ Spam delivered by servers with good reputations normally pass karma's checks.
 Expect to use karma *with* content filters.
 
 
-
 [p0f-url]: /manual/plugins/connect.p0f.html
 [geoip-url]: https://github.com/haraka/haraka-plugin-geoip
 [dnsbl-url]: /manual/plugins/dnsbl.html

--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ exports.register = function () {
 
   plugin.register_hook('connect_init', 'results_init');
   plugin.register_hook('connect_init', 'ip_history_from_redis');
-
-  plugin.server.notes.results_redis_publish = true;
 };
 
 exports.load_karma_ini = function () {


### PR DESCRIPTION
Reverts haraka/haraka-plugin-karma#9

This change is not necessary. Although the karma plugin uses redis pub/sub, it establishes a new redis connection (and psubscribe) for each Haraka connection.