### PR TITLE
Move redis.unsubscribe before skip check at disconnect

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+## 1.0.14 - 2022-02-14
+
+- try to unsubscribe in case connection is marked to skip during transaction
 
 ## 1.0.13 - 2019-04-23
 

--- a/index.js
+++ b/index.js
@@ -726,9 +726,9 @@ exports.increment = function (connection, key, val) {
 exports.hook_disconnect = function (next, connection) {
   const plugin = this;
 
-  if (plugin.should_we_skip(connection)) return next();
-
   plugin.redis_unsubscribe(connection);
+
+  if (plugin.should_we_skip(connection)) return next();
 
   const k = connection.results.get('karma');
   if (!k || k.score === undefined) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-karma",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "A heuristics scoring and reputation engine for SMTP connections",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If connection is marked to be skipped during transaction after karma init than Haraka&Redis might not close redis listeners and connections.