### PR TITLE
Release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,5 +193,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [2.3.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.3.0
 [2.4.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.0
 [2.4.1]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.1
-[2.4.2]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.2
 [2.5.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.5.0
+[2.5.1]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - dep(address-rfc2821): -> @haraka/email-address
 
+### [2.4.2] - 2026-05-20
+
+- fix: guard pubsub JSON.parse and validate payload shape in check_result
+- fix: guard new RegExp() in check_result_match against invalid config
+- fix: results_init fast-path now calls next() when notes.redis exists
+- fix: preserve originating plugin on awards so AUTH repeat-scoring works
+- fix: check_result_length measures collection length per karma.ini docs
+- fix: detect empty hGetAll ({}) in ip_history_from_redis and check_asn (node-redis v4)
+- docs: README threshold wording matches deny boundary
+
 ### [2.4.1] - 2026-05-13
 
 - fix: after trapping a denysoft, return denysoft later (vs deny)
@@ -183,4 +193,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [2.3.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.3.0
 [2.4.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.0
 [2.4.1]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.1
+[2.4.2]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.4.2
 [2.5.0]: https://github.com/haraka/haraka-plugin-karma/releases/tag/v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
-### [2.5.0] - 2026-05-17
-
-- dep(address-rfc2821): -> @haraka/email-address
-
-### [2.4.2] - 2026-05-20
+### [2.5.1] - 2026-05-24
 
 - fix: guard pubsub JSON.parse and validate payload shape in check_result
 - fix: guard new RegExp() in check_result_match against invalid config
@@ -17,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - fix: check_result_length measures collection length per karma.ini docs
 - fix: detect empty hGetAll ({}) in ip_history_from_redis and check_asn (node-redis v4)
 - docs: README threshold wording matches deny boundary
+
+### [2.5.0] - 2026-05-24
+
+- dep(address-rfc2821): -> @haraka/email-address
 
 ### [2.4.1] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In order to score a plugins results, plugins must save their results to the [Res
 
 ## How Karma Works
 
-Karma takes a holistic view of **connections**. During the connection, karma collects these results and applies the [result_awards](#awards) defined in `karma.ini`. Once a connection/message exceeds the threshold.negative score (default: -8), karma rejects it at the next [deny]hook.
+Karma takes a holistic view of **connections**. During the connection, karma collects these results and applies the [result_awards](#awards) defined in `karma.ini`. Once a connection/message reaches the threshold.negative score (default: -8), karma rejects it at the next [deny]hook.
 
 The scoring mechanism is not dissimilar to [SpamAssassin][sa-url], but Karma has some particular advantages:
 
@@ -51,7 +51,7 @@ Karma performs checks early and often, maximizing the penality it can exact upon
 
 ### Deny / Reject
 
-When connections become worse than [thresholds]negative, they are denied during the next [deny]hook.
+When a connection's score reaches [thresholds]negative (equal or lower), it is denied during the next [deny]hook.
 
 ### History
 

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ exports.results_init = async function (next, connection) {
 
   if (connection.notes.redis) {
     connection.logdebug(this, `redis already subscribed`)
-    return // another plugin has already called this.
+    return next() // another plugin has already called this.
   }
 
   connection.notes.redis = redis.createClient(this.redisCfg.pubsub)
@@ -134,7 +134,15 @@ exports.preparse_result_awards = function () {
 
     if (!ra[pi_name][prop]) ra[pi_name][prop] = []
 
-    ra[pi_name][prop].push({ id: anum, operator, value, award, reason, resolv })
+    ra[pi_name][prop].push({
+      id: anum,
+      plugin: pi_name,
+      operator,
+      value,
+      award,
+      reason,
+      resolv,
+    })
   }
 }
 
@@ -142,8 +150,17 @@ exports.check_result = function (connection, message) {
   // {"plugin":"karma","result":{"fail":"spamassassin.hits"}}
   // {"plugin":"geoip","result":{"country":"CN"}}
 
-  const m = JSON.parse(message)
-  if (m?.result?.asn) {
+  let m
+  try {
+    m = JSON.parse(message)
+  } catch (err) {
+    connection.logerror(this, `invalid pubsub payload: ${err.message}`)
+    return
+  }
+  if (!m || typeof m !== 'object' || typeof m.plugin !== 'string') return
+  if (!m.result || typeof m.result !== 'object') return
+
+  if (m.result.asn) {
     this.check_result_asn(m.result.asn, connection)
   }
   if (!this.result_awards[m.plugin]) return // no awards for plugin
@@ -247,7 +264,13 @@ exports.check_result_equal = function (thisResult, thisAward, conn) {
 }
 
 exports.check_result_match = function (thisResult, thisAward, conn) {
-  const re = new RegExp(thisAward.value, 'i')
+  let re
+  try {
+    re = new RegExp(thisAward.value, 'i')
+  } catch {
+    conn.results.add(this, { err: `invalid regex: ${thisAward.value}` })
+    return
+  }
 
   for (const element of thisResult) {
     if (!re.test(element)) continue
@@ -259,29 +282,31 @@ exports.check_result_match = function (thisResult, thisAward, conn) {
 }
 
 exports.check_result_length = function (thisResult, thisAward, conn) {
-  for (const element of thisResult) {
-    const [operator, qty] = thisAward.value.split(/\s+/)
+  const [operator, qty] = thisAward.value.split(/\s+/)
+  const len = thisResult.length
+  const threshold = parseFloat(qty)
 
-    switch (operator) {
-      case 'eq':
-      case 'equal':
-      case 'equals':
-        if (parseInt(element, 10) != parseInt(qty, 10)) continue
-        break
-      case 'gt':
-        if (parseInt(element, 10) <= parseInt(qty, 10)) continue
-        break
-      case 'lt':
-        if (parseInt(element, 10) >= parseInt(qty, 10)) continue
-        break
-      default:
-        conn.results.add(this, { err: `invalid operator: ${operator}` })
-        continue
-    }
-
-    conn.results.incr(this, { score: thisAward.award })
-    conn.results.push(this, { awards: thisAward.id })
+  switch (operator) {
+    case 'eq':
+    case 'equal':
+    case 'equals':
+      if (len !== threshold) return
+      break
+    case 'gt':
+      if (len <= threshold) return
+      break
+    case 'lt':
+      if (len >= threshold) return
+      break
+    default:
+      conn.results.add(this, { err: `invalid operator: ${operator}` })
+      return
   }
+
+  if (conn.results.has('karma', 'awards', thisAward.id)) return
+
+  conn.results.incr(this, { score: thisAward.award })
+  conn.results.push(this, { awards: thisAward.id })
 }
 
 exports.check_result_exists = function (thisResult, thisAward, conn) {
@@ -577,7 +602,7 @@ exports.ip_history_from_redis = async function (next, connection) {
   try {
     const dbr = await this.db.hGetAll(dbkey)
 
-    if (dbr === null) {
+    if (!dbr || Object.keys(dbr).length === 0) {
       this.init_ip(dbkey, connection.remote.ip, expire)
       return next()
     }
@@ -982,7 +1007,7 @@ exports.check_asn = async function (connection, asnkey) {
   try {
     const res = await this.db.hGetAll(asnkey)
 
-    if (res === null) {
+    if (!res || Object.keys(res).length === 0) {
       const expire = (this.cfg.redis.expire_days || 60) * 86400 // days
       this.init_asn(asnkey, expire)
       return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-karma",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A heuristics scoring and reputation engine for SMTP connections",
   "main": "index.js",
   "files": [

--- a/test/karma.js
+++ b/test/karma.js
@@ -86,6 +86,14 @@ describe('results_init', () => {
     plugin.results_init(stub, connection)
     assert.strictEqual(undefined, connection.results.get('karma'))
   })
+
+  it('calls next when another plugin already created notes.redis', async () => {
+    plugin.result_awards = { dnsbl: {} }
+    plugin.cfg.redis = {}
+    connection.server.notes.redis = { publish: () => {} }
+    connection.notes.redis = { existing: true }
+    await new Promise((resolve) => plugin.results_init(resolve, connection))
+  })
 })
 
 describe('should_we_skip', () => {
@@ -1272,9 +1280,9 @@ describe('check_result_length', () => {
 
   const base = { operator: 'length', reason: 'testing' }
 
-  it('eq match is scored', () => {
+  it('eq match on array length is scored', () => {
     plugin.check_result_length(
-      ['3'],
+      ['a', 'b', 'c'],
       makeAward({ ...base, value: 'eq 3' }),
       connection,
     )
@@ -1283,7 +1291,7 @@ describe('check_result_length', () => {
 
   it('eq mismatch is not scored', () => {
     plugin.check_result_length(
-      ['4'],
+      ['a', 'b'],
       makeAward({ ...base, value: 'eq 3' }),
       connection,
     )
@@ -1292,16 +1300,16 @@ describe('check_result_length', () => {
 
   it('gt match is scored', () => {
     plugin.check_result_length(
-      ['5'],
+      ['a', 'b', 'c', 'd'],
       makeAward({ ...base, value: 'gt 3' }),
       connection,
     )
     assert.strictEqual(2, connection.results.store.karma.score)
   })
 
-  it('gt mismatch is not scored', () => {
+  it('gt mismatch (at threshold) is not scored', () => {
     plugin.check_result_length(
-      ['3'],
+      ['a', 'b', 'c'],
       makeAward({ ...base, value: 'gt 3' }),
       connection,
     )
@@ -1310,25 +1318,34 @@ describe('check_result_length', () => {
 
   it('lt match is scored', () => {
     plugin.check_result_length(
-      ['2'],
+      ['a', 'b'],
       makeAward({ ...base, value: 'lt 3' }),
       connection,
     )
     assert.strictEqual(2, connection.results.store.karma.score)
   })
 
-  it('lt mismatch is not scored', () => {
+  it('lt mismatch (at threshold) is not scored', () => {
     plugin.check_result_length(
-      ['3'],
+      ['a', 'b', 'c'],
       makeAward({ ...base, value: 'lt 3' }),
       connection,
     )
     assert.strictEqual(undefined, connection.results.store.karma)
   })
 
+  it('gt 0 fires when a single value is present', () => {
+    plugin.check_result_length(
+      ['dnsbl.sorbs.net'],
+      makeAward({ ...base, value: 'gt 0' }),
+      connection,
+    )
+    assert.strictEqual(2, connection.results.store.karma.score)
+  })
+
   it('invalid operator is recorded as error', () => {
     plugin.check_result_length(
-      ['3'],
+      ['a'],
       makeAward({ ...base, value: 'invalid 3' }),
       connection,
     )
@@ -1408,6 +1425,14 @@ describe('preparse_result_awards', () => {
     assert.strictEqual('equals', plugin.result_awards.geoip.country[0].operator)
     assert.ok(plugin.result_awards.geoip.distance)
     assert.strictEqual('gt', plugin.result_awards.geoip.distance[0].operator)
+  })
+
+  it('stores originating plugin name on each award', () => {
+    plugin.cfg.result_awards = {
+      1: 'auth | fail | equals | true | -1 | bad auth | 0',
+    }
+    plugin.preparse_result_awards()
+    assert.strictEqual('auth', plugin.result_awards.auth.fail[0].plugin)
   })
 })
 
@@ -1536,6 +1561,51 @@ describe('check_result', () => {
       '{"plugin":"geoip","result":{"asn":"1234"}}',
     )
     assert.ok(called)
+  })
+
+  it('malformed JSON does not throw', () => {
+    plugin.result_awards = {}
+    let errLogged = false
+    connection.logerror = () => {
+      errLogged = true
+    }
+    assert.doesNotThrow(() => plugin.check_result(connection, 'not json {{{'))
+    assert.ok(errLogged)
+  })
+
+  it('non-object payload is ignored', () => {
+    plugin.result_awards = {}
+    assert.doesNotThrow(() => plugin.check_result(connection, '"a string"'))
+    assert.doesNotThrow(() => plugin.check_result(connection, 'null'))
+    assert.doesNotThrow(() => plugin.check_result(connection, '42'))
+  })
+
+  it('payload missing plugin field is ignored', () => {
+    plugin.result_awards = {}
+    assert.doesNotThrow(() =>
+      plugin.check_result(connection, '{"result":{"fail":"x"}}'),
+    )
+  })
+
+  it('invalid regex in award does not throw', () => {
+    plugin.cfg.result_awards = { 1: 'dnsbl | fail | match | [unclosed | -1' }
+    plugin.preparse_result_awards()
+    assert.doesNotThrow(() =>
+      plugin.check_result(
+        connection,
+        '{"plugin":"dnsbl","result":{"fail":"x"}}',
+      ),
+    )
+    assert.ok(connection.results.store.karma?.err?.length > 0)
+  })
+
+  it('repeated auth-plugin events are scored more than once', () => {
+    plugin.cfg.result_awards = { 1: 'auth | fail | equals | true | -1' }
+    plugin.preparse_result_awards()
+    const payload = '{"plugin":"auth","result":{"fail":true}}'
+    plugin.check_result(connection, payload)
+    plugin.check_result(connection, payload)
+    assert.strictEqual(-2, connection.results.store.karma.score)
   })
 })
 
@@ -1925,7 +1995,7 @@ describe('check_asn', () => {
   beforeEach(() => {
     ;({ plugin, connection } = _set_up())
     plugin.db = {
-      hGetAll: () => Promise.resolve(null),
+      hGetAll: () => Promise.resolve({}),
       hIncrBy: () => {},
     }
     plugin.init_asn = () => {}
@@ -2029,7 +2099,7 @@ describe('ip_history_from_redis', () => {
   let plugin, connection
   beforeEach(() => {
     ;({ plugin, connection } = _set_up())
-    plugin.db = { hGetAll: () => Promise.resolve(null) }
+    plugin.db = { hGetAll: () => Promise.resolve({}) }
     plugin.init_ip = () => {}
   })
 


### PR DESCRIPTION
- fix: guard pubsub JSON.parse and validate payload shape in check_result
- fix: guard new RegExp() in check_result_match against invalid config
- fix: results_init fast-path now calls next() when notes.redis exists
- fix: preserve originating plugin on awards so AUTH repeat-scoring works
- fix: check_result_length measures collection length per karma.ini docs
- fix: detect empty hGetAll ({}) in ip_history_from_redis and check_asn (node-redis v4)
- docs: README threshold wording matches deny boundary